### PR TITLE
Change upload URI format to https://bucket-name.s3.amazon.aws.com

### DIFF
--- a/lab-4/lambda/create-s3-upload-policy-document/index.js
+++ b/lab-4/lambda/create-s3-upload-policy-document/index.js
@@ -78,11 +78,12 @@ exports.handler = function(event, context, callback){
 
         callback(null, response);
       } else {
+        var UPLOAD_URI = process.env.UPLOAD_URI.replace('s3.',process.env.UPLOAD_BUCKET + '.s3.') + '/'
         var body = {
           signature: signature,
           encoded_policy: encoding,
           access_key: process.env.ACCESS_KEY,
-          upload_url: process.env.UPLOAD_URI + '/' + process.env.UPLOAD_BUCKET,
+          upload_url: UPLOAD_URI,
           key: key
         };
         var response = generateResponse(200, body);


### PR DESCRIPTION
This code was not working out of the box, at least in my region, eu-west-1.  The above code change allows the upload to go through and keeps the environmental variables the same. An alternative fix would be to specify the upload URI differently and change the code the other way. I've chosen this one as it's less redundant because it doesn't repeat the bucket name twice in the env variables.